### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/lupollm/76ee7d7b-c33c-425e-ac98-faec0f6569f1/b1696bc0-ce90-4e0a-b0af-f9ea775212de/_apis/work/boardbadge/eb67f83f-e17a-4047-9ace-5ed96b0fd25b)](https://dev.azure.com/lupollm/76ee7d7b-c33c-425e-ac98-faec0f6569f1/_boards/board/t/b1696bc0-ce90-4e0a-b0af-f9ea775212de/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/lupollm/76ee7d7b-c33c-425e-ac98-faec0f6569f1/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.